### PR TITLE
Common fixes

### DIFF
--- a/Demo/Pages/AnimationExpandAndCollapsePage.xaml.cs
+++ b/Demo/Pages/AnimationExpandAndCollapsePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using ListViewSample.Model;
 using LLM;
-using LLMListView;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/Demo/Pages/EmptyDataPage.xaml.cs
+++ b/Demo/Pages/EmptyDataPage.xaml.cs
@@ -1,11 +1,11 @@
 ﻿using ListViewSample.Model;
-using LLMListView;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using LLM;
 
 namespace Demo.Pages
 {

--- a/Demo/Pages/NormalFixPage.xaml.cs
+++ b/Demo/Pages/NormalFixPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using ListViewSample.Model;
 using LLM;
-using LLMListView;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/Demo/Pages/NormalFixPageRTL.xaml.cs
+++ b/Demo/Pages/NormalFixPageRTL.xaml.cs
@@ -24,6 +24,7 @@ namespace Demo.Pages
 {
     public sealed partial class NormalFixPageRTL : Page
     {
+        private FlowDirection _previousFlowDirection;
         ObservableCollection<Contact> _contacts = new ObservableCollection<Contact>();
 
         public ObservableCollection<Contact> Contacts
@@ -62,10 +63,17 @@ namespace Demo.Pages
             });
 
             Loaded += NormalFixPageRTL_Loaded;
+            Unloaded += NormalFixPageRTL_OnUnloaded;
+        }
+
+        private void NormalFixPageRTL_OnUnloaded(object sender, RoutedEventArgs e)
+        {
+            Frame.FlowDirection = _previousFlowDirection;
         }
 
         private void NormalFixPageRTL_Loaded(object sender, RoutedEventArgs e)
         {
+            _previousFlowDirection = Frame.FlowDirection;
             Frame.FlowDirection = FlowDirection.RightToLeft;
         }
 

--- a/Demo/Pages/NormalFixPageRTL.xaml.cs
+++ b/Demo/Pages/NormalFixPageRTL.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using ListViewSample.Model;
 using LLM;
-using LLMListView;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/Demo/Pages/RefreshButtonPage.xaml.cs
+++ b/Demo/Pages/RefreshButtonPage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using ListViewSample.Model;
 using LLM;
-using LLMListView;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/LLMListView/LLMListView.cs
+++ b/LLMListView/LLMListView.cs
@@ -14,7 +14,6 @@
 //   limitations under the License. 
 #endregion
 
-using LLMListView;
 using System;
 using Windows.ApplicationModel.Resources.Core;
 using Windows.Foundation;

--- a/LLMListView/LLMListView.cs
+++ b/LLMListView/LLMListView.cs
@@ -362,7 +362,7 @@ namespace LLM
 
         private void UpdateEmptyDataTemplateVisibility()
         {
-            if (EmptyDataTemplate == null) return;
+            if (EmptyDataTemplate == null || _itemsPresenter == null || _emptyTemplateControl == null) return;
             var itemsCount = Items?.Count ?? 0;
             if (itemsCount > 0)
             {

--- a/LLMListView/LLMListViewItem.cs
+++ b/LLMListView/LLMListViewItem.cs
@@ -14,7 +14,6 @@
 //   limitations under the License. 
 #endregion
 
-using LLMListView;
 using System;
 using Windows.Foundation;
 using Windows.UI.Xaml;

--- a/LLMListView/SwipeReleaseAnimationConstructor.cs
+++ b/LLMListView/SwipeReleaseAnimationConstructor.cs
@@ -14,7 +14,6 @@
 //   limitations under the License. 
 #endregion
 
-using LLMListView;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/LLMListView/Utils.cs
+++ b/LLMListView/Utils.cs
@@ -15,7 +15,6 @@
 #endregion
 
 using System;
-using Windows.ApplicationModel.Resources.Core;
 using Windows.Storage.Streams;
 using Windows.System.Profile;
 using Windows.UI.Xaml;
@@ -23,13 +22,13 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Media.Imaging;
 
-namespace LLMListView
+namespace LLM
 {
     public class Utils
     {
         public static DoubleAnimation CreateDoubleAnimation(DependencyObject target, string propertyPath, EasingFunctionBase easingFunc, double to, double duration)
         {
-            var anim = new DoubleAnimation()
+            var anim = new DoubleAnimation
             {
                 To = to,
                 Duration = new Duration(TimeSpan.FromMilliseconds(duration)),
@@ -44,40 +43,27 @@ namespace LLMListView
         {
             for (int i = 0; i < VisualTreeHelper.GetChildrenCount(obj); i++)
             {
-                DependencyObject child = VisualTreeHelper.GetChild(obj, i);
-                if (child != null && child is T && ((T)child).Name == childName)
-                    return (T)child;
-                else
-                {
-                    T childOfChild = FindVisualChild<T>(child, childName);
-                    if (childOfChild != null)
-                        return childOfChild;
-                }
+                var child = VisualTreeHelper.GetChild(obj, i);
+                var visualChild = child as T;
+                if (visualChild != null && visualChild.Name == childName) return visualChild;
+
+                var childOfChild = FindVisualChild<T>(child, childName);
+                if (childOfChild != null) return childOfChild;
             }
             return null;
         }
 
         public static T FindVisualParent<T>(DependencyObject obj) where T : DependencyObject
         {
-            DependencyObject parent = VisualTreeHelper.GetParent(obj);
-            if (parent is T)
-                return (T)parent;
-            else
-            {
-                T parentOfParent = FindVisualParent<T>(parent);
-                if (parentOfParent != null)
-                    return parentOfParent;
-            }
-            return null;
+            var parent = VisualTreeHelper.GetParent(obj);
+            var visualParent = parent as T;
+            if (visualParent != null) return visualParent;
+
+            var parentOfParent = FindVisualParent<T>(parent);
+            return parentOfParent;
         }
 
-        public static bool IsOnMobile
-        {
-            get
-            {
-                return AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile";
-            }
-        }
+        public static bool IsOnMobile => AnalyticsInfo.VersionInfo.DeviceFamily == "Windows.Mobile";
 
         public static async void SetBase64ToImage(BitmapSource imageSource, string base64Str)
         {


### PR DESCRIPTION
1. When EmptyDataTemplate defined and items binded to listview which isn't loaded -> NullException (e.g. when listview located on non-current pivot item).
2. All classes are located in LLM namespace, but Utils were in LLMListView namespace.
3. After RTL demo we should reset FlowDirection of current frame.
