### PR TITLE
LoadMore improvement

### DIFF
--- a/LLMListView/LLMListView.cs
+++ b/LLMListView/LLMListView.cs
@@ -356,6 +356,7 @@ namespace LLM
         protected override void OnItemsChanged(object e)
         {
             base.OnItemsChanged(e);
+            UpdateLoadingMore();
             UpdateEmptyDataTemplateVisibility();
         }
 
@@ -506,8 +507,10 @@ namespace LLM
 
         private void UpdateLoadingMore()
         {
+            if (LoadMore == null || _isLoadingMore || _scrollViewer == null) return;
+
             var bottomOffset = _scrollViewer.ExtentHeight - _scrollViewer.VerticalOffset - _scrollViewer.ViewportHeight;
-            if (!_isLoadingMore && LoadMore != null && bottomOffset < 300)
+            if (bottomOffset < 300)
             {
                 ToggleLoadingMoreStatus(true);
                 LoadMore();


### PR DESCRIPTION
1. LoadMore will be called only on scrolling but you can delete rows and scroll bar may disappear so scrolling will be impossible. => Now it's invoked also on collection changes.
2. There were waste scroll height calculations when LoadMore == null.
